### PR TITLE
Доделать Private: события

### DIFF
--- a/main-service/src/main/java/ru/practicum/ewm/category/service/CategoryServiceImpl.java
+++ b/main-service/src/main/java/ru/practicum/ewm/category/service/CategoryServiceImpl.java
@@ -9,6 +9,8 @@ import ru.practicum.ewm.category.dto.NewCategoryDto;
 import ru.practicum.ewm.category.mapper.CategoryMapper;
 import ru.practicum.ewm.category.model.Category;
 import ru.practicum.ewm.category.repository.CategoryRepository;
+import ru.practicum.ewm.event.repository.EventRepository;
+import ru.practicum.ewm.exception.ConflictDataException;
 import ru.practicum.ewm.exception.DuplicateException;
 import ru.practicum.ewm.exception.NotFoundException;
 
@@ -21,6 +23,7 @@ import java.util.List;
 public class CategoryServiceImpl implements CategoryService {
 
     private final CategoryRepository categoryRepository;
+    private final EventRepository eventRepository;
 
     @Transactional
     @Override
@@ -37,6 +40,9 @@ public class CategoryServiceImpl implements CategoryService {
     public void deleteCategory(Long catId) {
         if (!categoryRepository.existsById(catId)) {
             throw new NotFoundException("Категория не найдена");
+        }
+        if (eventRepository.existsByCategoryId(catId)) {
+            throw new ConflictDataException("Нельзя удалить категорию с привязанными событиями");
         }
         categoryRepository.deleteById(catId);
     }

--- a/main-service/src/main/java/ru/practicum/ewm/error/ErrorHandler.java
+++ b/main-service/src/main/java/ru/practicum/ewm/error/ErrorHandler.java
@@ -10,6 +10,7 @@ import org.springframework.web.method.annotation.MethodArgumentTypeMismatchExcep
 import ru.practicum.ewm.exception.ConflictDataException;
 import ru.practicum.ewm.exception.DuplicateException;
 import ru.practicum.ewm.exception.NotFoundException;
+import ru.practicum.ewm.exception.ValidationException;
 
 @RestControllerAdvice
 @Slf4j
@@ -57,6 +58,12 @@ public class ErrorHandler {
     @ResponseStatus(HttpStatus.NOT_FOUND)
     public ErrorResponse handleNotFound(final NotFoundException e) {
         log.debug("Получен статус 404 NOT_FOUND {}", e.getMessage(), e);
+        return new ErrorResponse(e.getMessage());
+    }
+
+    @ExceptionHandler
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ErrorResponse handleValidation(final ValidationException e) {
         return new ErrorResponse(e.getMessage());
     }
 }

--- a/main-service/src/main/java/ru/practicum/ewm/event/controller/PrivateEventController.java
+++ b/main-service/src/main/java/ru/practicum/ewm/event/controller/PrivateEventController.java
@@ -5,11 +5,9 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
-import ru.practicum.ewm.event.dto.EventFullDto;
-import ru.practicum.ewm.event.dto.EventShortDto;
-import ru.practicum.ewm.event.dto.NewEventDto;
-import ru.practicum.ewm.event.dto.UpdateEventUserRequest;
+import ru.practicum.ewm.event.dto.*;
 import ru.practicum.ewm.event.service.EventService;
+import ru.practicum.ewm.partrequest.dto.ParticipationRequestDto;
 
 import java.util.List;
 
@@ -40,8 +38,22 @@ public class PrivateEventController {
     }
 
     @PatchMapping("/{eventId}")
-    public EventFullDto updateEventOfUser(@Valid @RequestBody UpdateEventUserRequest updateRequest, @PathVariable Long userId,
+    public EventFullDto updateEventOfUser(@Valid @RequestBody UpdateEventUserRequest updateRequest,
+                                          @PathVariable Long userId,
                                           @PathVariable Long eventId) {
         return eventService.updateEventOfUser(updateRequest, userId, eventId);
+    }
+
+    @GetMapping("/{eventId}/requests")
+    public List<ParticipationRequestDto> getRequestsOfUserEvent(@PathVariable Long userId, @PathVariable Long eventId) {
+        return eventService.getRequestsOfUserEvent(userId, eventId);
+    }
+
+    @PatchMapping("/{eventId}/requests")
+    public List<ParticipationRequestDto> updateRequestsStatus(@PathVariable Long userId, @PathVariable Long eventId,
+                                                              @Valid @RequestBody
+                                                              EventRequestStatusUpdateRequest updateRequest) {
+        log.info("Получили запрос на обновление статусов заявок");
+        return eventService.updateRequestsStatus(updateRequest, userId, eventId);
     }
 }

--- a/main-service/src/main/java/ru/practicum/ewm/event/dto/EventRequestStatusUpdateRequest.java
+++ b/main-service/src/main/java/ru/practicum/ewm/event/dto/EventRequestStatusUpdateRequest.java
@@ -1,0 +1,23 @@
+package ru.practicum.ewm.event.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.FieldDefaults;
+import ru.practicum.ewm.event.enums.UpdateStatus;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@FieldDefaults(level = AccessLevel.PRIVATE)
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class EventRequestStatusUpdateRequest {
+    @NotNull
+    final List<Long> requestIds = new ArrayList<>();
+    @NotNull
+    UpdateStatus status;
+}

--- a/main-service/src/main/java/ru/practicum/ewm/event/enums/UpdateStatus.java
+++ b/main-service/src/main/java/ru/practicum/ewm/event/enums/UpdateStatus.java
@@ -1,0 +1,5 @@
+package ru.practicum.ewm.event.enums;
+
+public enum UpdateStatus {
+    CONFIRMED, REJECTED
+}

--- a/main-service/src/main/java/ru/practicum/ewm/event/repository/EventRepository.java
+++ b/main-service/src/main/java/ru/practicum/ewm/event/repository/EventRepository.java
@@ -8,4 +8,6 @@ import java.util.List;
 
 public interface EventRepository extends JpaRepository<Event, Long> {
     List<Event> findAllByInitiatorId(Long userId, PageRequest pageRequest);
+
+    Boolean existsByCategoryId(Long catId);
 }

--- a/main-service/src/main/java/ru/practicum/ewm/event/service/EventService.java
+++ b/main-service/src/main/java/ru/practicum/ewm/event/service/EventService.java
@@ -1,9 +1,7 @@
 package ru.practicum.ewm.event.service;
 
-import ru.practicum.ewm.event.dto.EventFullDto;
-import ru.practicum.ewm.event.dto.EventShortDto;
-import ru.practicum.ewm.event.dto.NewEventDto;
-import ru.practicum.ewm.event.dto.UpdateEventUserRequest;
+import ru.practicum.ewm.event.dto.*;
+import ru.practicum.ewm.partrequest.dto.ParticipationRequestDto;
 
 import java.util.List;
 
@@ -15,4 +13,9 @@ public interface EventService {
     EventFullDto getEventOfUser(Long userId, Long eventId);
 
     EventFullDto updateEventOfUser(UpdateEventUserRequest updateRequest, Long userId, Long eventId);
+
+    List<ParticipationRequestDto> getRequestsOfUserEvent(Long userId, Long eventId);
+
+    List<ParticipationRequestDto> updateRequestsStatus(EventRequestStatusUpdateRequest updateRequest, Long userId,
+                                                       Long eventId);
 }

--- a/main-service/src/main/java/ru/practicum/ewm/partrequest/repository/ParticipationRequestRepository.java
+++ b/main-service/src/main/java/ru/practicum/ewm/partrequest/repository/ParticipationRequestRepository.java
@@ -15,4 +15,6 @@ public interface ParticipationRequestRepository extends JpaRepository<Participat
     Optional<ParticipationRequest> findByRequesterIdAndId(Long requesterId, Long requestId);
 
     List<ParticipationRequest> findAllByRequesterId(Long requesterId);
+
+    List<ParticipationRequest> findAllByEventInitiatorIdAndEventId(Long userId, Long eventId);
 }


### PR DESCRIPTION
Реализовал эндпоинты:
1. Получение информации о запросах на участие в событии текущего пользователя
2. Изменение статуса (подтверждение, отмена) заявок на участие в событии текущего пользователя

Другие изменения:
1. Поправил даты start, end при запросе к сервису статистики при получении своих событий текущим пользователем
2. При попытке удалить категорию выбрасывается ошибка 409 CONFLICT, если есть связанные с ней события